### PR TITLE
fix(cordova): allow cleartext on localhost (#756)

### DIFF
--- a/integrations/cordova/config.xml
+++ b/integrations/cordova/config.xml
@@ -25,6 +25,10 @@
     <preference name="SplashScreen" value="screen" />
     <preference name="SplashScreenDelay" value="3000" />
     <platform name="android">
+        <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application" xmlns:android="http://schemas.android.com/apk/res/android">
+            <application android:networkSecurityConfig="@xml/network_security_config" />
+        </edit-config>
+        <resource-file src="resources/android/xml/network_security_config.xml" target="app/src/main/res/xml/network_security_config.xml" />
         <allow-intent href="market:*" />
         <icon density="ldpi" src="resources/android/icon/drawable-ldpi-icon.png" />
         <icon density="mdpi" src="resources/android/icon/drawable-mdpi-icon.png" />

--- a/integrations/cordova/resources/android/xml/network_security_config.xml
+++ b/integrations/cordova/resources/android/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain>localhost</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
Starting with Android 9, cleartext support is disabled by default. We
need to allow it again so livereload continues to work with `ionic
cordova run android`.

In CLI 5, the default host for the devserver is `localhost`, and traffic
on the devserver port is forwarded by native-run.

ref: https://github.com/ionic-team/ionic-cli/issues/3759
ref: https://developer.android.com/training/articles/security-config